### PR TITLE
DEP: drop public `test` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,5 @@ Home = "https://github.com/okken/pytest-skip-slow"
 [project.entry-points.pytest11]
 skip_slow = "pytest_skip_slow"
 
-[project.optional-dependencies]
-test = ["tox"]
-
 [tool.flit.module]
 name = "pytest_skip_slow"


### PR DESCRIPTION
It's not used internally and should probably not be user-visible anyway