### PR TITLE
DEP: simplify tox.ini dependency declarations

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ envlist =
 [testenv]
 deps = 
     pytest62: pytest==6.2.5
-    pytestlatest: pytest
     pytestmain: git+https://github.com/pytest-dev/pytest.git
 
 commands = pytest {posargs:tests}


### PR DESCRIPTION
This line can be dropped as redundant with project level dependencies.