### PR TITLE
ENH: add alias `--run-slow` flag to facilitate migration from `pytest-astropy`

### DIFF
--- a/pytest_skip_slow.py
+++ b/pytest_skip_slow.py
@@ -14,9 +14,13 @@ def pytest_configure(config):
 
 
 def pytest_addoption(parser):
-    parser.addoption("--slow", action="store_true",
-                     help="include tests marked slow")
-
+    parser.addoption(
+        "--slow",
+        "--run-slow",
+        dest="slow",
+        action="store_true",
+        help="include tests marked slow",
+    )
 
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--slow"):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -32,4 +32,4 @@ def test_run_only_slow(pytester, examples):
 
 def test_help(pytester):
     result = pytester.runpytest("--help")
-    result.stdout.fnmatch_lines(["*--slow * include tests marked slow*"])
+    result.stdout.fnmatch_lines(["*--slow, --run-slow * include tests marked slow*"])


### PR DESCRIPTION
This is designed to make migrating from pytest-astropy completely transparent.