### PR TITLE
RFC: refactor marker implementation to match pytest's current documentation

### DIFF
--- a/pytest_skip_slow.py
+++ b/pytest_skip_slow.py
@@ -19,8 +19,9 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(config, items):
-    if not config.getoption("--slow"):
-        skip_slow = pytest.mark.skip(reason="need --slow option to run")
-        for item in items:
-            if item.get_closest_marker("slow"):
-                item.add_marker(skip_slow)
+    run_slow = config.getoption("--slow")
+    skip_slow = pytest.mark.skip(reason="need --slow option to run")
+
+    for item in items:
+        if "slow" in item.keywords and not run_slow:
+            item.add_marker(skip_slow)


### PR DESCRIPTION
I don't know that it makes any difference at runtime (the test suite doesn't reveal any), but this more closely matches both the corresponding example from [pytest's own current documentation](https://docs.pytest.org/en/stable/example/simple.html#control-skipping-of-tests-according-to-command-line-option), and is how `pytest-astropy` does it, making addoption a no-brainer if anyone wants to audit the impl.