### PR TITLE
SEC: fix various vulns in GHA workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,11 +13,11 @@ jobs:
         python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox and any other packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: main
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   build:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,6 +2,8 @@ name: Publish to PyPI and TestPyPI
 
 on: push
 
+permissions: {}
+
 jobs:
   build-n-publish:
     name: Build and publish to PyPI and TestPyPI

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,11 +10,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.11"
     - name: Install pypa/build
@@ -22,11 +22,11 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python -m build --sdist --wheel --outdir dist/
     - name: Publish to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish to PyPI 
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
fixes were automatically generated using `zizmor --fix=all` + `pinact run --update`

- **SEC: disable default workflow permissions**
- **SEC: avoid leaking credentials**
- **SEC: upgrade and pin github actions**

The one remaining vulnerability I can't fix with just a PR is the use of a long lived PyPI token with write permission for publishing. Remediation requires migrating to trusted publishing.