### PR TITLE
REL: simplify pypa/build invoke with pipx

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -17,10 +17,8 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.11"
-    - name: Install pypa/build
-      run: python -m pip install build --user
     - name: Build a binary wheel and a source tarball
-      run: python -m build --sdist --wheel --outdir dist/
+      run: pipx run build
     # - name: Publish to Test PyPI
     #   uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
     #   with:


### PR DESCRIPTION
`pipx` is included with `actions/setup-python`, and none of the flags that were passed were changing anything with respect to the defaults.